### PR TITLE
Add blame and history support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-    :link: git-link
+    🔗 git-link
 </h1>
 <p align="center">Easily get the repository link to the current file, line or a selection</p>
 <p align="center">
@@ -29,19 +29,22 @@ Or search for the `git-link` package via `Settings > Packages`. Read more on [At
 
 ### Supported platforms
 
-- Works for GitHub.com (public, tested)
-- Works for GitLab.com (public, tested)
-- Works for BitBucket.org (public, tested)
-- Works for Azure DevOps (dev.azure.com) (public, tested)
+- Works for [GitHub.com](https://github.com) (public, tested)
+- Works for [GitLab.com](https://gitlab.com) (public, tested)
+- Works for [BitBucket.org](https://bitbucket.org) (public, tested)
+- Works for [Azure DevOps](https://dev.azure.com) (public, tested)
 - It might work for others (untested, PRs welcome)
+
+Please [add an issue](https://github.com/keevan/git-link/issues) if you need support for a platform not mentioned above.
 
 ### Features
 
-- Share and open what you've worked on, or a bug you've spotted.
+- Share and open what you've worked on, or a bug you've spotted
 - Copy a link to a __line__, __selection__ or __file__ for the current commit
+- Additional features added for _command-palette-plus_
 - Built with convenience in mind ([#tips](#Tips))
 - Handles non-typical file and folders okay - e.g. `[myfolder]/my#file.txt`
-- References markdown files in plaintext.
+- References markdown files in plaintext (on supported platforms)
 
 ### Command list
 No keymaps are currently set by default.
@@ -50,17 +53,17 @@ I recommended you configure your own keybindings and use what is comfortable for
 
 Command List                         | Description
 -------------------------------------|-------------
-`git-link:copy-link-to-line`         | Copies a link to the current line
-`git-link:copy-link-to-selection`    | Copies a link to the current selection
-`git-link:copy-link-to-file`         | Copies a link to the current file
-`git-link:copy-link-to-repository`   | Copies a link to the current repository
-`git-link:open-line-in-browser`      | Opens the link to the current line in browser
-`git-link:open-selection-in-browser` | Opens the link to the current selection in browser
-`git-link:open-file-in-browser`      | Opens the link to the current file in browser
-`git-link:open-repository-in-browser`| Opens the link to the current repository in browser
-`git-link:edit-line-in-browser`      | Opens __edit__ link to the current line in browser
-`git-link:edit-selection-in-browser` | Opens __edit__ link to the current selection in browser
-`git-link:edit-file-in-browser`      | Opens __edit__ link to the current file in browser
+`git-link:copy-link-to-line`         | __Copy__ a link to the current _line_
+`git-link:copy-link-to-selection`    | __Copy__ a link to the current _selection_
+`git-link:copy-link-to-file`         | __Copy__ a link to the current _file_
+`git-link:copy-link-to-repository`   | __Copy__ a link to the current _repository_
+`git-link:open-line-in-browser`      | __Open__ the current _line_ in browser
+`git-link:open-selection-in-browser` | __Open__ the current _selection_ in browser
+`git-link:open-file-in-browser`      | __Open__ the current _file_ in browser
+`git-link:open-repository-in-browser`| __Open__ the current _repository_ in browser
+`git-link:edit-line-in-browser`      | __Edit__ current _line_ in browser
+`git-link:edit-selection-in-browser` | __Edit__ current _selection_ in browser
+`git-link:edit-file-in-browser`      | __Edit__ current _file_ in browser
 
 
 ### Tips
@@ -89,7 +92,7 @@ Please take a look at our [contributing guidelines](./.github/CONTRIBUTING.md) i
 
 ### Support
 
-If you like this project or found it helpful, please consider supporting it for further development.
+If you like or found this project helpful, please leave a star and consider supporting it for further development.
 
 <a href="https://liberapay.com/kevinpham/donate"><img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg" style="height: 40px; padding-right: 10px">
 <a href="https://www.buymeacoffee.com/keevan" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 40px !important" ></a>

--- a/lib/git-link.js
+++ b/lib/git-link.js
@@ -71,6 +71,11 @@ export default {
       return commitHash
   },
 
+  /**
+   * Returns a path relative to the git repository root for the file. Note
+   * though the path is relative from the git repo root, it begins with a
+   * forward slash
+   */
   async getRelativePath(path) {
       let filePath = forwardFilePath(path);
       const { stdout: rootDirectory } = await git(['rev-parse', '--show-toplevel'])

--- a/lib/git-link.js
+++ b/lib/git-link.js
@@ -17,21 +17,29 @@ export default {
 
     // Register command that toggles this view
     this.subscriptions.add(atom.commands.add('atom-workspace', {
+      // Defaults
       'git-link:copy-link-to-line': () => this.linkLine(),
-      'git-link:copy-link-to-selection': () => this.linkSelection(),
-      'git-link:copy-link-to-file': () => this.linkFile(),
-      'git-link:copy-link-to-repository': () => this.linkRepository(),
-
-      // TODO: Add these commands
-      // 'git-link:copy-edit-link-to-line': () => this.linkLine(),
-      // 'git-link:copy-edit-link-to-selection': () => this.linkSelection(),
-      // 'git-link:copy-edit-link-to-file': () => this.linkFile(),
-
       'git-link:open-line-in-browser': () => this.openLine(),
+      'git-link:copy-link-to-selection': () => this.linkSelection(),
       'git-link:open-selection-in-browser': () => this.openSelection(),
+      'git-link:copy-link-to-file': () => this.linkFile(),
       'git-link:open-file-in-browser': () => this.openFile(),
+      'git-link:copy-link-to-repository': () => this.linkRepository(),
       'git-link:open-repository-in-browser': () => this.openRepository(),
 
+      // Blame support
+      'git-link:copy-blame-for-line': () => this.blameLine(),
+      'git-link:open-blame-for-line': () => this.openBlameLine(),
+      'git-link:copy-blame-for-selection': () => this.blameSelection(),
+      'git-link:open-blame-for-selection': () => this.openBlameSelection(),
+      'git-link:copy-blame-for-file': () => this.blameFile(),
+      'git-link:open-blame-for-file': () => this.openBlameFile(),
+
+      // History (commits) support
+      'git-link:copy-history-for-file': () => this.historyFile(),
+      'git-link:open-history-for-file': () => this.openHistoryFile(),
+
+      // Edit support
       'git-link:edit-line-in-browser': () => this.editLine(),
       'git-link:edit-selection-in-browser': () => this.editSelection(),
       'git-link:edit-file-in-browser': () => this.editFile(),
@@ -80,14 +88,14 @@ export default {
   },
 
   // Core methods
-  async file() {
+  async file({ blame = false } = {}) {
       const p = await this.getPlatform()
       const relativePath = await this.getRelativePath(filePath())
       const commitHash = await this.getCommitHash()
-      return p.getFileLink({ commitHash, relativePath })
+      return p.getFileLink({ commitHash, relativePath, blame })
   },
 
-  async line() {
+  async line({ blame = false } = {}) {
       // Must have an active editor.
       const editor = atom.workspace.getActiveTextEditor()
       if (!editor) {
@@ -109,10 +117,10 @@ export default {
       // Select text in line (based on mental heuristic - might be a hit or miss)
       // TODO
 
-      return p.getLineLink({ relativePath, commitHash, start, startColumn, endColumn })
+      return p.getLineLink({ relativePath, commitHash, start, startColumn, endColumn, blame })
   },
 
-  async selection() {
+  async selection({ blame = false } = {}) {
       // Must have an active editor.
       const editor = atom.workspace.getActiveTextEditor()
       if (!editor) {
@@ -130,10 +138,10 @@ export default {
 
       // Return the shorter version if the end line is on the same line.
       if (end === start) {
-          return p.getLineLink({ relativePath, commitHash, start, startColumn, endColumn })
+          return p.getLineLink({ relativePath, commitHash, start, startColumn, endColumn, blame })
       }
 
-      return p.getSelectionLink({ relativePath, commitHash, start, end, startColumn, endColumn })
+      return p.getSelectionLink({ relativePath, commitHash, start, end, startColumn, endColumn, blame })
   },
 
   /**
@@ -166,6 +174,42 @@ export default {
   async linkRepository() {
       const link = await this.repository()
       this.handleCopy(link, 'Copied link for current repository to clipboard')
+  },
+
+  // Blame
+  async blameLine() {
+      const link = await this.line({ blame: true })
+      this.handleCopy(link, 'Copied blame link for current line to clipboard')
+  },
+  async openBlameLine() {
+      const link = await this.line({ blame: true })
+      shell.openExternal(link);
+  },
+  async blameSelection() {
+      const link = await this.selection({ blame: true })
+      this.handleCopy(link, 'Copied blame link for current selection to clipboard')
+  },
+  async openBlameSelection() {
+      const link = await this.selection({ blame: true })
+      shell.openExternal(link);
+  },
+  async blameFile() {
+      const link = await this.file({ blame: true })
+      this.handleCopy(link, 'Copied blame link for current file to clipboard')
+  },
+  async openBlameFile() {
+      const link = await this.file({ blame: true })
+      shell.openExternal(link);
+  },
+
+  // History
+  async historyFile() {
+      const link = await this.file({ history: true })
+      this.handleCopy(link, 'Copied history link for current file to clipboard')
+  },
+  async openHistoryFile() {
+      const link = await this.file({ history: true })
+      shell.openExternal(link);
   },
 
   handleCopy(link, message = '') {

--- a/lib/platforms/azure.js
+++ b/lib/platforms/azure.js
@@ -6,13 +6,13 @@ export default function ({ repo }) {
     this.repo = repo.replace(regex, subst);
 
     return {
+        getPullRequestsLink: () => {
+            return `${this.repo}/pullrequests`
+        },
         getRepoDisplay: () => {
             const template = 'https://{%endpoint%}/{%username%}/{%project%}/_git/{{repository}}'
             const { username, project, repository } = tmpl(repo, template)
             return `${username}/${project}/${repository}`
-        },
-        getPullRequestsLink: () => {
-            return `${repo}/pullrequests`
         },
         getRepo: () => this.repo,
         hostsRepo: ({ host }) => {
@@ -24,14 +24,31 @@ export default function ({ repo }) {
             // Otherwise..
             return false
         },
-
-        getSelectionLink: ({ commitHash, relativePath, start, end, startColumn = 1, endColumn = 2 }) => {
+        getSelectionLink: ({ commitHash, relativePath, start, end, startColumn = 1, endColumn = 2, blame = false }) => {
             if (endColumn === 1) {
                 end++
             }
-          return `${this.repo}?path=${relativePath}&version=GC${commitHash}&line=${start}&lineEnd=${end}&lineStartColumn=${startColumn}&lineEndColumn=${endColumn}`
+            let mode = ''
+            if (blame) {
+                mode = '&_a=blame'
+            }
+            return `${this.repo}?path=${relativePath}&version=GC${commitHash}&line=${start}&lineEnd=${end}&lineStartColumn=${startColumn}&lineEndColumn=${endColumn}${mode}`
         },
-        getLineLink: ({ commitHash, relativePath, start, startColumn = 1, endColumn = 2 }) => `${this.repo}?path=${relativePath}&version=GC${commitHash}&line=${start}&lineEnd=${start}&lineStartColumn=${startColumn}&lineEndColumn=${endColumn}`,
-        getFileLink: ({ commitHash, relativePath }) => `${this.repo}?path=${relativePath}&version=GC${commitHash}`,
+        getLineLink: ({ commitHash, relativePath, start, startColumn = 1, endColumn = 2, blame = false }) => {
+            let mode = ''
+            if (blame) {
+                mode = '&_a=blame'
+            }
+            return `${this.repo}?path=${relativePath}&version=GC${commitHash}&line=${start}&lineEnd=${start}&lineStartColumn=${startColumn}&lineEndColumn=${endColumn}${mode}`
+        },
+        getFileLink: ({ commitHash, relativePath, blame = false, history = false }) => {
+            let mode = ''
+            if (blame) {
+                mode = '&_a=blame'
+            } else if (history) {
+                mode = '&_a=history'
+            }
+            return `${this.repo}?path=${relativePath}&version=GC${commitHash}${mode}`
+        },
     }
 }

--- a/lib/platforms/bitbucket.js
+++ b/lib/platforms/bitbucket.js
@@ -3,6 +3,12 @@ import tmpl from 'reverse-string-template'
 
 export default function ({ repo }) {
     return {
+        getPullRequestsLink: () => {
+            return `${repo}/pull-requests`
+        },
+        getIssuesLink: () => {
+            return `${repo}/issues`
+        },
         getRepoDisplay: () => {
             const template = 'https://{%endpoint%}/{%username%}/{{repository}}'
             const { username, repository } = tmpl(repo, template)

--- a/lib/platforms/bitbucket.js
+++ b/lib/platforms/bitbucket.js
@@ -22,8 +22,28 @@ export default function ({ repo }) {
             // Otherwise..
             return false
         },
-        getSelectionLink: ({ commitHash, relativePath, start, end }) => `${repo}/src/${toShortHash(commitHash)}${relativePath}#lines-${start}:${end}`,
-        getLineLink: ({ commitHash, relativePath, start }) => `${repo}/src/${toShortHash(commitHash)}${relativePath}#lines-${start}`,
-        getFileLink: ({ commitHash, relativePath }) => `${repo}/src/${toShortHash(commitHash)}${relativePath}`,
+        getSelectionLink: ({ commitHash, relativePath, start, end, blame = false }) => {
+            let mode = 'src'
+            if (blame) {
+                mode = 'annotate'
+            }
+            return `${repo}/${mode}/${toShortHash(commitHash)}${relativePath}#-${start}:${end}`
+        },
+        getLineLink: ({ commitHash, relativePath, start, blame = false }) => {
+            let mode = 'src'
+            if (blame) {
+                mode = 'annotate'
+            }
+            return `${repo}/${mode}/${toShortHash(commitHash)}${relativePath}#-${start}`
+        },
+        getFileLink: ({ commitHash, relativePath, blame = false, history = false }) => {
+            let mode = 'src'
+            if (blame) {
+                mode = 'annotate'
+            } else if (history) {
+                mode = 'commits'
+            }
+            return `${repo}/${mode}/${toShortHash(commitHash)}${relativePath}`
+        },
     }
 }

--- a/lib/platforms/github.js
+++ b/lib/platforms/github.js
@@ -31,21 +31,17 @@ export default function ({ repo }) {
             // Otherwise..
             return false
         },
-        getSelectionLink: ({ commitHash, relativePath, start, end, blame = false, history = false }) => {
+        getSelectionLink: ({ commitHash, relativePath, start, end, blame = false }) => {
             let mode = 'blob'
             if (blame) {
                 mode = 'blame'
-            } else if (history) {
-                mode = 'commits'
             }
             return `${repo}/${mode}/${toShortHash(commitHash)}${relativePath}#L${start}-L${end}`
         },
-        getLineLink: ({ commitHash, relativePath, start, blame = false, history = false }) => {
+        getLineLink: ({ commitHash, relativePath, start, blame = false }) => {
             let mode = 'blob'
             if (blame) {
                 mode = 'blame'
-            } else if (history) {
-                mode = 'commits'
             }
             return `${repo}/${mode}/${toShortHash(commitHash)}${relativePath}#L${start}`
         },

--- a/lib/platforms/github.js
+++ b/lib/platforms/github.js
@@ -31,8 +31,32 @@ export default function ({ repo }) {
             // Otherwise..
             return false
         },
-        getSelectionLink: ({ commitHash, relativePath, start, end }) => `${repo}/blob/${toShortHash(commitHash)}${relativePath}#L${start}-L${end}`,
-        getLineLink: ({ commitHash, relativePath, start }) => `${repo}/blob/${toShortHash(commitHash)}${relativePath}#L${start}`,
-        getFileLink: ({ commitHash, relativePath }) => `${repo}/blob/${toShortHash(commitHash)}${relativePath}`,
+        getSelectionLink: ({ commitHash, relativePath, start, end, blame = false, history = false }) => {
+            let mode = 'blob'
+            if (blame) {
+                mode = 'blame'
+            } else if (history) {
+                mode = 'commits'
+            }
+            return `${repo}/${mode}/${toShortHash(commitHash)}${relativePath}#L${start}-L${end}`
+        },
+        getLineLink: ({ commitHash, relativePath, start, blame = false, history = false }) => {
+            let mode = 'blob'
+            if (blame) {
+                mode = 'blame'
+            } else if (history) {
+                mode = 'commits'
+            }
+            return `${repo}/${mode}/${toShortHash(commitHash)}${relativePath}#L${start}`
+        },
+        getFileLink: ({ commitHash, relativePath, blame = false, history = false }) => {
+            let mode = 'blob'
+            if (blame) {
+                mode = 'blame'
+            } else if (history) {
+                mode = 'commits'
+            }
+            return `${repo}/${mode}/${toShortHash(commitHash)}${relativePath}`
+        },
     }
 }

--- a/lib/platforms/gitlab.js
+++ b/lib/platforms/gitlab.js
@@ -35,8 +35,8 @@ export default function ({ repo }) {
             // Otherwise..
             return false
         },
-        getSelectionLink: ({ commitHash, relativePath, start, end }) => `${repo}/blob/${toShortHash(commitHash)}${relativePath}#L${start}-${end}`,
-        getLineLink: ({ commitHash, relativePath, start }) => `${repo}/blob/${toShortHash(commitHash)}${relativePath}#L${start}`,
-        getFileLink: ({ commitHash, relativePath }) => `${repo}/blob/${toShortHash(commitHash)}${relativePath}`,
+        getSelectionLink: ({ commitHash, relativePath, start, end }) => `${repo}/-/blob/${toShortHash(commitHash)}${relativePath}#L${start}-${end}`,
+        getLineLink: ({ commitHash, relativePath, start }) => `${repo}/-/blob/${toShortHash(commitHash)}${relativePath}#L${start}`,
+        getFileLink: ({ commitHash, relativePath }) => `${repo}/-/blob/${toShortHash(commitHash)}${relativePath}`,
     }
 }

--- a/lib/platforms/gitlab.js
+++ b/lib/platforms/gitlab.js
@@ -35,8 +35,28 @@ export default function ({ repo }) {
             // Otherwise..
             return false
         },
-        getSelectionLink: ({ commitHash, relativePath, start, end }) => `${repo}/-/blob/${toShortHash(commitHash)}${relativePath}#L${start}-${end}`,
-        getLineLink: ({ commitHash, relativePath, start }) => `${repo}/-/blob/${toShortHash(commitHash)}${relativePath}#L${start}`,
-        getFileLink: ({ commitHash, relativePath }) => `${repo}/-/blob/${toShortHash(commitHash)}${relativePath}`,
+        getSelectionLink: ({ commitHash, relativePath, start, end, blame = false }) => {
+            let mode = 'blob'
+            if (blame) {
+                mode = 'blame'
+            }
+            return `${repo}/-/${mode}/${toShortHash(commitHash)}${relativePath}#L${start}-${end}`
+        },
+        getLineLink: ({ commitHash, relativePath, start, blame = false }) => {
+            let mode = 'blob'
+            if (blame) {
+                mode = 'blame'
+            }
+            return `${repo}/-/${mode}/${toShortHash(commitHash)}${relativePath}#L${start}`
+        },
+        getFileLink: ({ commitHash, relativePath, blame = false, history = false }) => {
+            let mode = 'blob'
+            if (blame) {
+                mode = 'blame'
+            } else if (history) {
+                mode = 'commits'
+            }
+            return `${repo}/-/${mode}/${toShortHash(commitHash)}${relativePath}`
+        },
     }
 }

--- a/spec/git-link-spec.js
+++ b/spec/git-link-spec.js
@@ -25,7 +25,7 @@ describe('GitLink', () => {
     })
 
     describe('Test platform support - github', () => {
-        it("has to detect github", () => {
+        it("has to detect github", async () => {
             const urls = [
              'git@github.com:keevan/git-link.git',
              'https://github.com/keevan/git-link',
@@ -37,6 +37,46 @@ describe('GitLink', () => {
                 const resolvedRepo = p.getRepo()
                 expect('https://github.com/keevan/git-link').toEqual(resolvedRepo)
             })
+
+        })
+        it("has to support relevant links", async () => {
+            // Given a github repo
+            const url = 'git@github.com:keevan/git-link.git'
+            const commitHash = 'abc1234'
+            // Resolve the platform
+            const repo = GitLink.getRepoFromOrigin(url)
+            const p = await platform.create({ repo })
+            // Issues page
+            expect('https://github.com/keevan/git-link/issues').toEqual(p.getIssuesLink())
+            // Pull Requests page
+            expect('https://github.com/keevan/git-link/pulls').toEqual(p.getPullRequestsLink())
+
+            // Test for different types of links (file)
+            const relativePath = '/path/to/file'
+            // Normal
+            expect(`https://github.com/keevan/git-link/blob/${commitHash}${relativePath}`)
+                .toEqual(p.getFileLink({ commitHash, relativePath }))
+            // Blame
+            expect(`https://github.com/keevan/git-link/blame/${commitHash}${relativePath}`)
+                .toEqual(p.getFileLink({ commitHash, relativePath, blame: true }))
+            // History
+            expect(`https://github.com/keevan/git-link/commits/${commitHash}${relativePath}`)
+                .toEqual(p.getFileLink({ commitHash, relativePath, history: true }))
+            // Test for different types of links (selection)
+            const start = 10
+            const end = 15
+            // Normal - line
+            expect(`https://github.com/keevan/git-link/blob/${commitHash}${relativePath}#L10`)
+                .toEqual(p.getLineLink({ commitHash, relativePath, start }))
+            // Normal - selection
+            expect(`https://github.com/keevan/git-link/blob/${commitHash}${relativePath}#L10-L15`)
+                .toEqual(p.getSelectionLink({ commitHash, relativePath, start, end }))
+            // Blame - line
+            expect(`https://github.com/keevan/git-link/blame/${commitHash}${relativePath}#L10`)
+                .toEqual(p.getLineLink({ commitHash, relativePath, start, blame: true }))
+            // Blame - selection
+            expect(`https://github.com/keevan/git-link/blame/${commitHash}${relativePath}#L10-L15`)
+                .toEqual(p.getSelectionLink({ commitHash, relativePath, start, end, blame: true }))
         })
     })
 
@@ -53,6 +93,44 @@ describe('GitLink', () => {
                 const resolvedRepo = p.getRepo()
                 expect('https://gitlab.com/user/repo').toEqual(resolvedRepo)
             })
+        })
+        it("has to support relevant links", async () => {
+            // Given a github repo
+            const url = 'git@gitlab.com:user/repo.git'
+            const commitHash = 'abc1234'
+            // Resolve the platform
+            const repo = GitLink.getRepoFromOrigin(url)
+            const p = await platform.create({ repo })
+            // Issues page
+            expect('https://gitlab.com/user/repo/-/issues').toEqual(p.getIssuesLink())
+            // Pull Requests page
+            expect('https://gitlab.com/user/repo/-/merge_requests').toEqual(p.getPullRequestsLink())
+            // Test for different types of links (file)
+            const relativePath = '/path/to/file'
+            // Normal
+            expect(`https://gitlab.com/user/repo/-/blob/${commitHash}${relativePath}`)
+                .toEqual(p.getFileLink({ commitHash, relativePath }))
+            // Blame
+            expect(`https://gitlab.com/user/repo/-/blame/${commitHash}${relativePath}`)
+                .toEqual(p.getFileLink({ commitHash, relativePath, blame: true }))
+            // History
+            expect(`https://gitlab.com/user/repo/-/commits/${commitHash}${relativePath}`)
+                .toEqual(p.getFileLink({ commitHash, relativePath, history: true }))
+            // Test for different types of links (selection)
+            const start = 10
+            const end = 15
+            // Normal - line
+            expect(`https://gitlab.com/user/repo/-/blob/${commitHash}${relativePath}#L10`)
+                .toEqual(p.getLineLink({ commitHash, relativePath, start }))
+            // Normal - selection
+            expect(`https://gitlab.com/user/repo/-/blob/${commitHash}${relativePath}#L10-15`)
+                .toEqual(p.getSelectionLink({ commitHash, relativePath, start, end }))
+            // Blame - line
+            expect(`https://gitlab.com/user/repo/-/blame/${commitHash}${relativePath}#L10`)
+                .toEqual(p.getLineLink({ commitHash, relativePath, start, blame: true }))
+            // Blame - selection
+            expect(`https://gitlab.com/user/repo/-/blame/${commitHash}${relativePath}#L10-15`)
+                .toEqual(p.getSelectionLink({ commitHash, relativePath, start, end, blame: true }))
         })
     })
 
@@ -87,6 +165,45 @@ describe('GitLink', () => {
                 const resolvedRepo = p.getRepo()
                 expect('https://bitbucket.org/user/repo').toEqual(resolvedRepo)
             })
+        })
+
+        it("has to support relevant links", async () => {
+            // Given a github repo
+            const url = 'git@bitbucket.org:user/repo.git'
+            const commitHash = 'abc1234'
+            // Resolve the platform
+            const repo = GitLink.getRepoFromOrigin(url)
+            const p = await platform.create({ repo })
+            // Issues page
+            expect('https://bitbucket.org/user/repo/issues').toEqual(p.getIssuesLink())
+            // Pull Requests page
+            expect('https://bitbucket.org/user/repo/pull-requests').toEqual(p.getPullRequestsLink())
+            // Test for different types of links (file)
+            const relativePath = '/path/to/file'
+            // Normal
+            expect(`https://bitbucket.org/user/repo/src/${commitHash}${relativePath}`)
+                .toEqual(p.getFileLink({ commitHash, relativePath }))
+            // 'Blame' is annotate for bitbucket - https://jira.atlassian.com/browse/BCLOUD-16318
+            expect(`https://bitbucket.org/user/repo/annotate/${commitHash}${relativePath}`)
+                .toEqual(p.getFileLink({ commitHash, relativePath, blame: true }))
+            // History
+            expect(`https://bitbucket.org/user/repo/commits/${commitHash}${relativePath}`)
+                .toEqual(p.getFileLink({ commitHash, relativePath, history: true }))
+            // Test for different types of links (selection)
+            const start = 10
+            const end = 15
+            // Normal - line
+            expect(`https://bitbucket.org/user/repo/src/${commitHash}${relativePath}#-10`)
+                .toEqual(p.getLineLink({ commitHash, relativePath, start }))
+            // Normal - selection
+            expect(`https://bitbucket.org/user/repo/src/${commitHash}${relativePath}#-10:15`)
+                .toEqual(p.getSelectionLink({ commitHash, relativePath, start, end }))
+            // Blame - line
+            expect(`https://bitbucket.org/user/repo/annotate/${commitHash}${relativePath}#-10`)
+                .toEqual(p.getLineLink({ commitHash, relativePath, start, blame: true }))
+            // Blame - selection
+            expect(`https://bitbucket.org/user/repo/annotate/${commitHash}${relativePath}#-10:15`)
+                .toEqual(p.getSelectionLink({ commitHash, relativePath, start, end, blame: true }))
         })
     })
 


### PR DESCRIPTION
For these 2 in particular, it seems it's more important that the reference point (e.g. commit hash, branch, etc.) is available, but this should be moved to a new issue as it affects existing links too.

Fixes #27 
Fixes #22 